### PR TITLE
Ip 241 ruff ordering

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,5 @@
 
 # Black code formatting of entire repository
 2967ed10ef6e38d4346735c1693212a56c756902
+# Ruff import ordering of entire repository
+07f98e056802caaae31a92025155bfcf53b24bb1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     rev: v0.3.4
     hooks:
       - id: ruff
-        args: ["--fix", "--show-fixes"]
+        args: ["--fix", "--show-fixes", "--select", "I"]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.3.0
     hooks:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,10 +1,11 @@
 """ End-to-end tests of the Harmony Regridding service. """
 
-from os.path import exists, join as path_join
+from os.path import exists
+from os.path import join as path_join
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
-from unittest.mock import patch, ANY
+from unittest.mock import ANY, patch
 
 from harmony.message import Message
 from harmony.util import config
@@ -16,8 +17,7 @@ from harmony_regridding_service.exceptions import (
     InvalidTargetCRS,
     InvalidTargetGrid,
 )
-
-from tests.utilities import create_stac, Granule
+from tests.utilities import Granule, create_stac
 
 
 class TestAdapter(TestCase):

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from harmony.message import Message
-from harmony.util import config, HarmonyException
+from harmony.util import HarmonyException, config
 
 from harmony_regridding_service.adapter import RegriddingServiceAdapter
 from harmony_regridding_service.exceptions import (
@@ -9,7 +9,7 @@ from harmony_regridding_service.exceptions import (
     InvalidTargetCRS,
     InvalidTargetGrid,
 )
-from tests.utilities import create_stac, Granule
+from tests.utilities import Granule, create_stac
 
 
 class TestAdapter(TestCase):

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from harmony.util import bbox_to_geometry
 from pystac import Asset, Catalog, Item
 
-
 Granule = namedtuple('Granule', ['url', 'media_type', 'roles'])
 
 


### PR DESCRIPTION
## Description

Another PR that propagates the sorting of imports by `ruff`. (This repo likely won't see any action for a little while 😢)

Also, until my NAMS request gets fulfilled, this repo will be private and the pre-commit.ci won't run successfully (so the CI/CD will be marked as a failure). If we want to wait until that is changed, so we can kick off the check and know for sure, then I'm fine to do that, but I want to have the PR so we don't lose track of this change.

## Jira Issue ID

N/A

## Local Test Steps

N/A

## PR Acceptance Checklist
* ~~Jira ticket acceptance criteria met.~~
* ~~`CHANGELOG.md` updated to include high level summary of PR changes.~~
* ~~`docker/service_version.txt` updated if publishing a release.~~
* ~~Tests added/updated and passing.~~
* ~~Documentation updated (if needed).~~