### PR TITLE
DAS-2367 handle multiple target areas for implicit grids

### DIFF
--- a/harmony_regridding_service/crs.py
+++ b/harmony_regridding_service/crs.py
@@ -7,6 +7,7 @@ from pyresample.geometry import AreaDefinition
 from varinfo import VarInfoFromNetCDF4
 
 from harmony_regridding_service.dimensions import (
+    GridDimensionPair,
     horizontal_dims_for_variable,
 )
 from harmony_regridding_service.file_io import (
@@ -15,7 +16,7 @@ from harmony_regridding_service.file_io import (
 
 
 def get_crs_variable_name(
-    dim_pair: tuple[str, str], resampled_dim_pairs: list[tuple[str, str]]
+    dim_pair: GridDimensionPair, resampled_dim_pairs: list[GridDimensionPair]
 ) -> str:
     """Return a crs variable name for this dimension pair.
 
@@ -38,8 +39,8 @@ def get_crs_variable_name(
 
 def write_grid_mappings(
     target_ds: Dataset,
-    resampled_dim_pairs: list[tuple[str, str]],
-    target_area: AreaDefinition,
+    resampled_dim_pairs: list[GridDimensionPair],
+    target_areas: dict[GridDimensionPair, AreaDefinition],
 ) -> dict:
     """Add coordinate reference system metadata variables.
 
@@ -50,10 +51,9 @@ def write_grid_mappings(
     pointing back to the correct crs variable in the regridded variables.
 
     """
-    crs_metadata = target_area.crs.to_cf()
     crs_map = {}
-
     for dim_pair in resampled_dim_pairs:
+        crs_metadata = target_areas[dim_pair].crs.to_cf()
         crs_variable_name = get_crs_variable_name(dim_pair, resampled_dim_pairs)
         var = PurePath(crs_variable_name)
         t_group = target_ds.createGroup(var.parent)

--- a/harmony_regridding_service/dimensions.py
+++ b/harmony_regridding_service/dimensions.py
@@ -1,19 +1,28 @@
 """Module for handling dimension variables."""
 
 from collections.abc import Iterable
+from typing import NamedTuple
 
 from varinfo import VarInfoFromNetCDF4
 
 
+class GridDimensionPair(NamedTuple):
+    """Horizontal grid dimensions."""
+
+    dim1: str
+    dim2: str
+
+
 def horizontal_dims_for_variable(
     var_info: VarInfoFromNetCDF4, var_name: str
-) -> tuple[str, str]:
+) -> GridDimensionPair:
     """Return the horizontal dimensions for desired variable."""
     group_vars = var_info.group_variables_by_horizontal_dimensions()
-    return next(
+    dim_pair = next(
         (dims for dims, var_names in group_vars.items() if var_name in var_names),
         None,
     )
+    return GridDimensionPair(*dim_pair) if dim_pair else None
 
 
 def get_row_dims(dims: Iterable[str], var_info: VarInfoFromNetCDF4) -> str:
@@ -56,14 +65,14 @@ def is_row_dim(dim: str, var_info: VarInfoFromNetCDF4) -> str:
 
 def get_resampled_dimension_pairs(
     var_info: VarInfoFromNetCDF4,
-) -> list[tuple[str, str]]:
+) -> list[GridDimensionPair]:
     """Return a list of the resampled horizontal spatial dimensions.
 
     Gives a list of the 2-element horizontal dimensions that are used in
     regridding this granule file.
     """
     return [
-        dims
+        GridDimensionPair(*dims)
         for dims in var_info.group_variables_by_horizontal_dimensions()
         if len(dims) == 2
     ]

--- a/harmony_regridding_service/grid.py
+++ b/harmony_regridding_service/grid.py
@@ -181,11 +181,7 @@ def get_geographic_area_extent(
 
     """
     lons, lats = projected_area.get_lonlats()
-    min_lon = np.min(lons)
-    max_lon = np.max(lats)
-    min_lat = np.min(lons)
-    max_lat = np.max(lats)
-    return (min_lon, min_lat, max_lon, max_lat)
+    return (np.min(lons), np.min(lats), np.max(lons), np.max(lats))
 
 
 def reorder_extents(min_x, min_y, max_x, max_y):

--- a/harmony_regridding_service/resample.py
+++ b/harmony_regridding_service/resample.py
@@ -13,6 +13,7 @@ from pyresample.geometry import AreaDefinition, SwathDefinition
 from varinfo import VarInfoFromNetCDF4
 
 from harmony_regridding_service.dimensions import (
+    GridDimensionPair,
     get_column_dims,
     get_resampled_dimension_pairs,
     get_row_dims,
@@ -176,7 +177,7 @@ def copy_resampled_bounds_variable(
     source_ds: Dataset,
     target_ds: Dataset,
     bounds_var: str,
-    target_area: AreaDefinition,
+    target_areas: dict[GridDimensionPair, AreaDefinition],
     var_info: VarInfoFromNetCDF4,
 ):
     """Copy computed values for dimension variable bounds variables."""
@@ -185,9 +186,11 @@ def copy_resampled_bounds_variable(
     xdims = get_column_dims(var_dims, var_info)
     ydims = get_row_dims(var_dims, var_info)
     if xdims:
+        target_area = target_areas[get_dim_pair_by_dim(xdims[0], var_info)]
         target_coords = target_area.projection_x_coords
         dim_name = xdims[0]
     else:
+        target_area = target_areas[get_dim_pair_by_dim(ydims[0], var_info)]
         target_coords = target_area.projection_y_coords
         dim_name = ydims[0]
 
@@ -266,7 +269,7 @@ def resampled_dimension_variable_names(var_info: VarInfoFromNetCDF4) -> set[str]
 def create_resampled_dimensions(
     resampled_dim_pairs: list[tuple[str, str]],
     dataset: Dataset,
-    target_area: AreaDefinition,
+    target_areas: dict[GridDimensionPair, AreaDefinition],
     var_info: VarInfoFromNetCDF4,
 ):
     """Create dimensions for the target resampled grids."""
@@ -274,8 +277,12 @@ def create_resampled_dimensions(
         xdim = get_column_dims(set(dim_pair), var_info)[0]
         ydim = get_row_dims(set(dim_pair), var_info)[0]
 
-        create_dimension(dataset, xdim, target_area.projection_x_coords.shape[0])
-        create_dimension(dataset, ydim, target_area.projection_y_coords.shape[0])
+        create_dimension(
+            dataset, xdim, target_areas[dim_pair].projection_x_coords.shape[0]
+        )
+        create_dimension(
+            dataset, ydim, target_areas[dim_pair].projection_y_coords.shape[0]
+        )
 
 
 def unresampled_variables(var_info: VarInfoFromNetCDF4) -> set[str]:
@@ -305,29 +312,26 @@ def get_resampled_dimensions(var_info: VarInfoFromNetCDF4) -> set[str]:
 
 
 def cache_resamplers(
-    filepath: str, var_info: VarInfoFromNetCDF4, target_area: AreaDefinition
+    filepath: str,
+    var_info: VarInfoFromNetCDF4,
+    target_areas: dict[GridDimensionPair, AreaDefinition],
 ) -> None:
     """Precompute the resampling weights.
 
-    Use the regridding target area in conjunction with each 2D horizontal
-    dimension pair in the input source file to create an resampler and precompute
-    the weights to be used when resampling.
+    Use the regridding target areas in conjunction with each 2D grid dimension
+    pair in the input source file to create an resampler and precompute the
+    weights to be used when resampling.
 
     """
     grid_cache = {}
-
-    dimension_vars_mapping = var_info.group_variables_by_horizontal_dimensions()
-
-    for dimensions in dimension_vars_mapping:
-        # create swath definitions from each unique 2D grid dimensions found in
-        # the input file.
-        if len(dimensions) == 2:
-            logger.debug(f'computing weights for dimensions {dimensions}')
-            source_swath = compute_source_swath(dimensions, filepath, var_info)
-            grid_cache[dimensions] = DaskEWAResampler(source_swath, target_area)
-            grid_cache[dimensions].precompute(
-                rows_per_scan=get_rows_per_scan(source_swath.shape[0]),
-            )
+    for dim_pair in get_resampled_dimension_pairs(var_info):
+        logger.debug(f'computing weights for dimensions {dim_pair}')
+        # create swath definitions for each grid in the source file.
+        source_swath = compute_source_swath(dim_pair, filepath, var_info)
+        grid_cache[dim_pair] = DaskEWAResampler(source_swath, target_areas[dim_pair])
+        grid_cache[dim_pair].precompute(
+            rows_per_scan=get_rows_per_scan(source_swath.shape[0]),
+        )
 
     return grid_cache
 
@@ -357,7 +361,7 @@ def compute_source_swath(
 def transfer_resampled_dimensions(
     source_ds: Dataset,
     target_ds: Dataset,
-    target_area: AreaDefinition,
+    target_areas: dict[GridDimensionPair, AreaDefinition],
     var_info: VarInfoFromNetCDF4,
 ) -> None:
     """Transfer all dimensions from source to target.
@@ -373,26 +377,27 @@ def transfer_resampled_dimensions(
     copy_dimensions(unchanged_dimensions, source_ds, target_ds)
 
     create_resampled_dimensions(
-        resampled_dimension_pairs, target_ds, target_area, var_info
+        resampled_dimension_pairs, target_ds, target_areas, var_info
     )
 
 
 def copy_resampled_dimension_variables(
     source_ds: Dataset,
     target_ds: Dataset,
-    target_area: AreaDefinition,
+    target_areas: dict[GridDimensionPair, AreaDefinition],
     var_info: VarInfoFromNetCDF4,
 ) -> set[str]:
     """Copy over dimension variables that are changed in the target file."""
     dim_var_names = resampled_dimension_variable_names(var_info)
+
     processed_vars = copy_1d_dimension_variables(
-        source_ds, target_ds, dim_var_names, target_area, var_info
+        source_ds, target_ds, dim_var_names, target_areas, var_info
     )
 
     bounds_vars = dim_var_names - processed_vars
     for bounds_var in bounds_vars:
         processed_vars |= copy_resampled_bounds_variable(
-            source_ds, target_ds, bounds_var, target_area, var_info
+            source_ds, target_ds, bounds_var, target_areas, var_info
         )
 
     return processed_vars
@@ -532,7 +537,7 @@ def copy_1d_dimension_variables(
     source_ds: Dataset,
     target_ds: Dataset,
     dim_var_names: set[str],
-    target_area: AreaDefinition,
+    target_areas: dict[GridDimensionPair, AreaDefinition],
     var_info: VarInfoFromNetCDF4,
 ) -> set[str]:
     """Copy 1 dimensional dimension variables.
@@ -551,6 +556,8 @@ def copy_1d_dimension_variables(
     ydims = get_row_dims(one_d_vars, var_info)
 
     for dim_name in one_d_vars:
+        # Get correct area for this dimension.
+        target_area = target_areas[get_dim_pair_by_dim(dim_name, var_info)]
         if dim_name in xdims:
             target_coords = target_area.projection_x_coords
             standard_metadata = {
@@ -581,6 +588,18 @@ def copy_1d_dimension_variables(
         t_var[:] = target_coords
 
     return one_d_vars
+
+
+def get_dim_pair_by_dim(
+    dim_name: str,
+    var_info: VarInfoFromNetCDF4,
+):
+    """Get the horizontal dimension pair containing a particular dimension."""
+    return next(
+        dim_pair
+        for dim_pair in get_resampled_dimension_pairs(var_info)
+        if dim_name in dim_pair
+    )
 
 
 def get_bounds_var(var_info: VarInfoFromNetCDF4, dim_name: str) -> str:

--- a/tests/unit/test_crs.py
+++ b/tests/unit/test_crs.py
@@ -107,6 +107,7 @@ def test_write_grid_mappings(
     target_file = test_file
     var_info = var_info_fxn(test_1D_dimensions_ncfile)
     _generate_test_area = test_area_fxn()
+    test_areas = {('/lon', '/lat'): _generate_test_area}
     expected_crs_map = {('/lon', '/lat'): '/crs'}
 
     with (
@@ -114,12 +115,10 @@ def test_write_grid_mappings(
         Dataset(target_file, mode='w') as target_ds,
     ):
         transfer_metadata(source_ds, target_ds)
-        transfer_resampled_dimensions(
-            source_ds, target_ds, _generate_test_area, var_info
-        )
+        transfer_resampled_dimensions(source_ds, target_ds, test_areas, var_info)
 
         actual_crs_map = write_grid_mappings(
-            target_ds, get_resampled_dimension_pairs(var_info), _generate_test_area
+            target_ds, get_resampled_dimension_pairs(var_info), test_areas
         )
         assert expected_crs_map == actual_crs_map
 

--- a/tests/unit/test_file_io.py
+++ b/tests/unit/test_file_io.py
@@ -125,14 +125,14 @@ def test_copy_var_with_attrs(
     test_file, test_area_fxn, test_1D_dimensions_ncfile, var_info_fxn
 ):
     target_file = test_file
-    target_area = test_area_fxn()
+    target_areas = {('/lon', '/lat'): test_area_fxn()}
     var_info = var_info_fxn(test_1D_dimensions_ncfile)
     expected_metadata = {'units': 'widgets per month'}
     with (
         Dataset(test_1D_dimensions_ncfile, mode='r') as source_ds,
         Dataset(target_file, mode='w') as target_ds,
     ):
-        transfer_resampled_dimensions(source_ds, target_ds, target_area, var_info)
+        transfer_resampled_dimensions(source_ds, target_ds, target_areas, var_info)
         copy_var_with_attrs(source_ds, target_ds, '/data')
 
     with Dataset(target_file, mode='r') as validate:
@@ -147,7 +147,7 @@ def test_copy_vars_without_metadata(
     test_file, test_area_fxn, test_1D_dimensions_ncfile, var_info_fxn
 ):
     target_file = test_file
-    target_area = test_area_fxn()
+    target_area = {('/lon', '/lat'): test_area_fxn()}
     var_info = var_info_fxn(test_1D_dimensions_ncfile)
     with (
         Dataset(test_1D_dimensions_ncfile, mode='r') as source_ds,
@@ -172,16 +172,14 @@ def test_clone_variables(
     width = 36
     height = 18
 
-    _generate_test_area = test_area_fxn(width=width, height=height)
+    test_areas = {('/lon', '/lat'): test_area_fxn(width=width, height=height)}
 
     copy_vars = {'/time', '/time_bnds'}
     with (
         Dataset(test_1D_dimensions_ncfile, mode='r') as source_ds,
         Dataset(target_file, mode='w') as target_ds,
     ):
-        transfer_resampled_dimensions(
-            source_ds, target_ds, _generate_test_area, var_info
-        )
+        transfer_resampled_dimensions(source_ds, target_ds, test_areas, var_info)
 
         copied = clone_variables(source_ds, target_ds, copy_vars)
 

--- a/tests/unit/test_regridding_service.py
+++ b/tests/unit/test_regridding_service.py
@@ -20,7 +20,7 @@ test_scale_extent = {
     'width, height, scale_extent, expected_width, expected_height, description',
     [
         (100, 50, test_scale_extent, 100, 50, 'Grid parameters are provided.'),
-        (None, None, None, 5, 6, 'Grid parameters are excluded from message.'),
+        (None, None, None, 5, 9, 'Grid parameters are excluded from message.'),
     ],
 )
 def test_regrid_projected_data_end_to_end(

--- a/tests/unit/test_resample.py
+++ b/tests/unit/test_resample.py
@@ -260,6 +260,7 @@ def test_copy_resampled_bounds_variable(
 ):
     target_file = test_file
     target_area = test_area_fxn()
+    target_areas = {('/Grid/lon', '/Grid/lat'): target_area}
     var_info = var_info_fxn(test_IMERG_ncfile)
     bnds_var = '/Grid/lat_bnds'
     var_copied = None
@@ -275,10 +276,10 @@ def test_copy_resampled_bounds_variable(
         Dataset(test_IMERG_ncfile, mode='r') as source_ds,
         Dataset(target_file, mode='w') as target_ds,
     ):
-        transfer_resampled_dimensions(source_ds, target_ds, target_area, var_info)
+        transfer_resampled_dimensions(source_ds, target_ds, target_areas, var_info)
 
         var_copied = copy_resampled_bounds_variable(
-            source_ds, target_ds, bnds_var, target_area, var_info
+            source_ds, target_ds, bnds_var, target_areas, var_info
         )
 
     assert {bnds_var} == var_copied
@@ -328,13 +329,11 @@ def test_create_resampled_dimensions_root_dimensions(
     var_info = var_info_fxn(test_1D_dimensions_ncfile)
     width = 36
     height = 18
-    _generate_test_area = test_area_fxn(width=width, height=height)
+    test_areas = {('/lat', '/lon'): test_area_fxn(width=width, height=height)}
     target_file = test_file
 
     with Dataset(target_file, mode='w') as target_ds:
-        create_resampled_dimensions(
-            [('/lat', '/lon')], target_ds, _generate_test_area, var_info
-        )
+        create_resampled_dimensions([('/lat', '/lon')], target_ds, test_areas, var_info)
 
     with Dataset(target_file, mode='r') as validate:
         assert validate.dimensions['lat'].size == 18
@@ -348,13 +347,13 @@ def test_create_resampled_dimensions_group_level_dimensions(
     test_file,
 ):
     var_info = var_info_fxn(test_IMERG_ncfile)
-    _generate_test_area = test_area_fxn()
+    test_areas = {('/Grid/lon', '/Grid/lat'): test_area_fxn()}
     target_file = test_file
     with Dataset(target_file, mode='w') as target_ds:
         create_resampled_dimensions(
             [('/Grid/lon', '/Grid/lat')],
             target_ds,
-            _generate_test_area,
+            test_areas,
             var_info,
         )
 
@@ -431,16 +430,14 @@ def test_transfer_resampled_dimensions(
     """
     width = 36
     height = 18
-    _generate_test_area = test_area_fxn(width=width, height=height)
+    test_areas = {('/lon', '/lat'): test_area_fxn(width=width, height=height)}
     var_info = var_info_fxn(test_1D_dimensions_ncfile)
     target_file = test_file
     with (
         Dataset(test_1D_dimensions_ncfile, mode='r') as source_ds,
         Dataset(target_file, mode='w') as target_ds,
     ):
-        transfer_resampled_dimensions(
-            source_ds, target_ds, _generate_test_area, var_info
-        )
+        transfer_resampled_dimensions(source_ds, target_ds, test_areas, var_info)
 
     with Dataset(target_file, mode='r') as validate:
         assert validate.dimensions['bnds'].size == 2
@@ -459,7 +456,7 @@ def test_copy_resampled_dimension_variables(
     target_file = test_file
     width = 300
     height = 150
-    target_area = test_area_fxn(width=width, height=height)
+    target_areas = {('/lat', '/lon'): test_area_fxn(width=width, height=height)}
     var_info = var_info_fxn(test_MERRA2_ncfile)
     expected_vars_copied = {'/lon', '/lat'}
 
@@ -467,10 +464,10 @@ def test_copy_resampled_dimension_variables(
         Dataset(test_MERRA2_ncfile, mode='r') as source_ds,
         Dataset(target_file, mode='w') as target_ds,
     ):
-        transfer_resampled_dimensions(source_ds, target_ds, target_area, var_info)
+        transfer_resampled_dimensions(source_ds, target_ds, target_areas, var_info)
 
         vars_copied = copy_resampled_dimension_variables(
-            source_ds, target_ds, target_area, var_info
+            source_ds, target_ds, target_areas, var_info
         )
 
         assert expected_vars_copied == vars_copied
@@ -572,6 +569,7 @@ def test_copy_1d_dimension_variables(
 ):
     target_file = test_file
     target_area = test_area_fxn()
+    target_areas = {('/lon', '/lat'): target_area}
     var_info = var_info_fxn(test_1D_dimensions_ncfile)
     dim_var_names = {'/lon', '/lat'}
     expected_attributes = {'long_name', 'standard_name', 'units'}
@@ -580,9 +578,9 @@ def test_copy_1d_dimension_variables(
         Dataset(test_1D_dimensions_ncfile, mode='r') as source_ds,
         Dataset(target_file, mode='w') as target_ds,
     ):
-        transfer_resampled_dimensions(source_ds, target_ds, target_area, var_info)
+        transfer_resampled_dimensions(source_ds, target_ds, target_areas, var_info)
         vars_copied = copy_1d_dimension_variables(
-            source_ds, target_ds, dim_var_names, target_area, var_info
+            source_ds, target_ds, dim_var_names, target_areas, var_info
         )
 
     assert dim_var_names == vars_copied


### PR DESCRIPTION
## Description

This PR has a couple of main changes.

1. compute_target_area -> compute_target_areas
	Instead of returning an AreaDefinition, it returns a dict[GridDimensionPair, AreaDefinition]. If the target grids are determined implicitly, there will be an AreaDefinition for each horizontal grid pair / GridDimensionPair / source Grid.

This mapping of horizontal grid to target areas is carried throughout the code and the appropriate grid is used for resampling, as well as dimension propagation.

2. The assumption in the previous code that the Projected AreaDefintion had a geographic bounding box given by areaDefintion.area_extent_ll is no longer valid as we have to handle non-global projections (North and South polar). We now take a projected areaDefintion, get the lon and lat values of every grid cell and then compute a bounding box from all of the values with     Geographic_area_extent = (np.min(lons), np.min(lats), np.max(lons), np.max(lats)).  This DOES now mean that we are excluding edges of our grid in the global case. e.g. we no longer compute the edges of the grid cells in the projected space to get the lon/lat bounds for global grids.  We only have the information from the lon/lat centers based on pyresaples AreaDefinition.get_lonlats()

3. The resolution of the target grid is now computed based on the conversion from meters to degrees for the WGS84 equatorial radius of 6,378,137.

## Jira Issue ID

[DAS-2367](https://bugs.earthdata.nasa.gov/browse/DAS-2367)

## Local Test Steps


## PR Acceptance Checklist
* [ ] Jira ticket acceptance criteria met.
* [ ] `CHANGELOG.md` updated to include high level summary of PR changes and link to release.
* [ ] `docker/service_version.txt` updated if publishing a release.
* [ ] Tests added/updated and passing.
* [ ] Documentation updated (if needed).
